### PR TITLE
All view should emit doc._id

### DIFF
--- a/server/models/bank.coffee
+++ b/server/models/bank.coffee
@@ -9,7 +9,7 @@ module.exports = Bank = americano.getModel 'bank',
 
 
 Bank.all = (callback) ->
-    Bank.request "all", callback
+    Bank.request "allByName", callback
 
 
 Bank.createOrUpdate = (bank, callback) ->

--- a/server/models/bankaccount.coffee
+++ b/server/models/bankaccount.coffee
@@ -9,7 +9,7 @@ module.exports = BankAccount = americano.getModel 'bankaccount',
     lastChecked: Date
 
 BankAccount.all = (callback) ->
-    BankAccount.request "all", callback
+    BankAccount.request "allByTitle", callback
 
 BankAccount.allLike = (account, callback) ->
     params =

--- a/server/models/requests.coffee
+++ b/server/models/requests.coffee
@@ -24,7 +24,7 @@ getBanksWithAccounts =
 
 module.exports =
     bank:
-        all: allByName
+        allByName: allByName
         byUuid: byUuid
 
     bankaccess:
@@ -33,7 +33,7 @@ module.exports =
         allLike: allAccessesLike
 
     bankaccount:
-        all: allByTitle
+        allByTitle: allByTitle
         allByBankAccess: allByBankAccess
         allByBank: allByBank
         allLike: allAccountsLike


### PR DESCRIPTION
In the next data-system version, we want to unify 'all' views to improve couchDB indentation.

For that, data-system will manage a view which will emit doc.docType, doc._id . To access to all 'bank' document, data-system will call this view with correct key.

Thus, 'all' view in application should emit doc._id.