### PR TITLE
Management of operation types

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,9 @@
     },
     "KresusConfig": {
       "description": "Une paire de clé-valeur pour sauvegarder des éléments de configuration de Kresus."
+    },
+    "operationtype": {
+      "description": "Un type d'opération bancaire"
     }
   }
 }

--- a/server/init.coffee
+++ b/server/init.coffee
@@ -7,7 +7,15 @@ module.exports = (app, server, callback) ->
     Bank = require './models/bank'
     CozyInstance = require './models/cozyinstance'
     AllBanksData = require "../../weboob/banks-all.json"
-
+    AllOperationTypes = require "../../weboob/operation-types.json"
+    OperationTypes = require './models/operationtype'
+    # Bank Operation type initialisation
+    console.log "Maybe Adding operation types"
+    async.each AllOperationTypes, OperationTypes.checkAndCreate, (err) ->
+        if err?
+            console.error "Error when adding operation: #{err}"
+            return
+        console.log "Success: all operation types added."
     # Bank initialization
     console.log "Maybe Adding banks..."
     async.each AllBanksData, Bank.createOrUpdate, (err) ->
@@ -16,7 +24,6 @@ module.exports = (app, server, callback) ->
             return
         console.log "Success: All banks added."
         callback app, server if callback?
-
     # Start bank polling
     console.log "Starting bank accounts polling..."
     require('./lib/accounts-poller').start()

--- a/server/lib/weboob-fetch.coffee
+++ b/server/lib/weboob-fetch.coffee
@@ -147,6 +147,7 @@ exports.InstallOrUpdateWeboob = InstallOrUpdateWeboob = (forceUpdate, cb) ->
     attempts = 1
 
     tryInstall = (force) ->
+        console.log "OK here we are"
         InstallOrUpdateWeboob force, (err) ->
 
             if err?

--- a/server/lib/weboob-manager.coffee
+++ b/server/lib/weboob-manager.coffee
@@ -6,6 +6,8 @@ NotificationsHelper = require 'cozy-notifications-helper'
 
 BankOperation = require '../models/bankoperation'
 BankAccount = require '../models/bankaccount'
+OperationType = require '../models/operationtype'
+
 
 appData = require '../../package.json'
 alertManager = require './alert-manager'
@@ -98,6 +100,7 @@ class WeboobManager
                     dateImport: now.format "YYYY-MM-DDTHH:mm:ss.000Z"
                     raw: operationWeboob.raw
                     bankAccount: relatedAccount
+                    operationTypeID: OperationType.getOperationTypeID(+operationWeboob.type)
                 operations.push operation
 
             @processRetrievedOperations operations, callback

--- a/server/models/bankoperation.coffee
+++ b/server/models/bankoperation.coffee
@@ -8,6 +8,7 @@ module.exports = BankOperation = americano.getModel 'bankoperation',
     raw: String
     dateImport: Date
     categoryId: String
+    operationTypeID: String
     # Binary is an object containing one field (file) that links to a binary
     # document via an id. The binary document has a binary file
     # as attachment.

--- a/server/models/operationtype.coffee
+++ b/server/models/operationtype.coffee
@@ -1,0 +1,54 @@
+americano = require 'americano'
+
+module.exports = OperationType = americano.getModel 'operationtype',
+    name: String
+    weboobvalue: Number
+
+ListOperationType = {}
+
+OperationType.all = (callback) ->
+    OperationType.request "all", callback
+
+
+OperationType.checkAndCreate = (operationtype, callback) ->
+    params = key: operationtype.weboobvalue
+    OperationType.request "byWeboobValue", params, (err, found) ->
+        if err?
+            callback err
+            return
+
+        if found? and found.length >= 1
+            ListOperationType["#{found[0].weboobvalue}"] = 
+                name: found[0].name
+                id: found[0].id
+            console.log "Operationtype with weboobvalue #{operationtype.weboobvalue} already exists!"
+            callback null
+            return
+
+        else
+            console.log "Creating operationtype with weboobvalue #{operationtype.weboobvalue}..."
+            OperationType.create operationtype, (err,created) -> 
+                if err?
+                    callback err
+    
+                ListOperationType["#{operationtype.weboobvalue}"] =
+                    name: created.name
+                    id: created.id
+                callback null
+                return
+
+OperationType.getOperationTypeID = (weboobvalue) ->
+    if ListOperationType["#{weboobvalue}"]?
+        return ListOperationType[weboobvalue].id
+    else
+        console.error "Error: #{weboobvalue} is undefined, pleace contact kresus maintener"
+        return ListOperationType[0].id
+
+OperationType.getAllOperationType = () ->
+    OperationType.all (err, found) ->
+        if err?
+            console.log "Error when retrieving operation types"
+        for operationtype in found
+            ListOperationType["#{operationtype.weboobvalue}"] =
+                name: operationtype.name
+                id: created.id

--- a/server/models/requests.coffee
+++ b/server/models/requests.coffee
@@ -22,6 +22,9 @@ getBanksWithAccounts =
     reduce: (keys, values, rereduce) ->
         return 1
 
+allByWeboobValue = (doc) ->
+    emit doc.weboobvalue, doc
+
 module.exports =
     bank:
         all: allByName
@@ -59,3 +62,7 @@ module.exports =
     kresusconfig:
         all: americano.defaultRequests.all
         byName: allByName
+        
+    operationtype:
+        all:americano.defaultRequests.all
+        byWeboobValue: allByWeboobValue

--- a/weboob/operation-types.json
+++ b/weboob/operation-types.json
@@ -1,0 +1,57 @@
+[ 
+    {
+        "docType": "operationtype", 
+        "weboobvalue": 0,
+        "name": "t.unknown"
+    },
+    {
+        "docType": "operationtype", 
+        "weboobvalue": 1,
+        "name": "t.transfer"
+    },
+    {
+        "docType": "operationtype", 
+        "weboobvalue": 2,
+        "name": "t.order"
+    },
+    {
+        "docType": "operationtype", 
+        "weboobvalue": 3,
+        "name": "t.check"
+    },
+    { 
+        "docType": "operationtype",
+        "weboobvalue": 4,
+        "name": "t.deposit"
+    },
+    { 
+        "docType": "operationtype",
+        "weboobvalue": 5,
+        "name": "t.payback"
+    },
+    { 
+        "docType": "operationtype",
+        "weboobvalue": 6,
+        "name": "t.withdrawal"
+    },
+    { 
+        "docType": "operationtype",
+        "weboobvalue": 7,
+        "name": "t.card"
+    },
+    { 
+        "docType": "operationtype",
+        "weboobvalue": 8,
+        "name": "t.loan_payment"
+    },
+    { 
+        "docType": "operationtype",
+        "weboobvalue": 9,
+        "name": "t.bankfee"
+    },
+    { 
+        "docType": "operationtype",
+        "weboobvalue": 10,
+        "name": "t.cash_deposit"
+    }    
+]

--- a/weboob/py/connector.py
+++ b/weboob/py/connector.py
@@ -48,7 +48,8 @@ class Connector(object):
                         "date": history.date.strftime(DATETIME_FORMAT),
                         "rdate": history.rdate.strftime(DATETIME_FORMAT),
                         "label": unicode(history.label),
-                        "raw": unicode(history.raw)
+                        "raw": unicode(history.raw),
+                        "type": history.type
                     })
             except NotImplementedError:
                 print "The account type has not been implemented by weboob."


### PR DESCRIPTION


Following discussion of https://github.com/bnjbvr/kresus/pull/102
Here is the import of operation type inside the DB. I tookes into consideration all your comment.
Method getAllOperationType is not used, but can easily be changed to a method returning ListOperationType (useful to transmit the list of operation types without requesting them to the datasystem as the ListOperationType is created at the start up of the server).

Currently the operation types are not updated if the file containing them is changed. Maybe it should be
