### PR TITLE
Added custom fields to bank accounts

### DIFF
--- a/client/Models.js
+++ b/client/Models.js
@@ -5,7 +5,7 @@ export class Bank {
         this.id   = has(arg, 'id')   && arg.id;
         this.name = has(arg, 'name') && arg.name;
         this.uuid = has(arg, 'uuid') && arg.uuid;
-        this.websites = arg.websites;
+        this.customFields = arg.customFields;
 
         this.accounts = [];
     }

--- a/client/backend.js
+++ b/client/backend.js
@@ -162,13 +162,13 @@ module.exports = {
         });
     },
 
-    addBank: function(uuid, id, pwd, maybeWebsite) {
+    addBank: function(uuid, id, pwd, maybeCustomFields) {
         return new Promise((accept, reject) => {
             $.post('accesses/', {
                 bank: uuid,
                 login: id,
                 password: pwd,
-                website: maybeWebsite
+                customFields: maybeCustomFields ? JSON.stringify(maybeCustomFields) : maybeCustomFields
             }, accept).fail(xhrReject(reject));
         });
     },

--- a/client/locales/fr.js
+++ b/client/locales/fr.js
@@ -142,7 +142,12 @@ module.exports = {
 
     settings: {
         column_account_name: 'Nom',
+        unknown_field_type: 'Type de champ incorrect',
         website: 'Site régional',
+        birthday: "Date d'anniversaire",
+        birthdayPlaceholder: "JJMMAAAA",
+        secret: "Phrase secrète",
+        secretPlaceholder: "Entrez votre phrase secrète ici",
         bank: 'Banque',
         login: 'Identifiant',
         password: 'Mot de passe',

--- a/client/store.js
+++ b/client/store.js
@@ -272,8 +272,8 @@ store.importInstance = function(content) {
 }
 
 // BANKS
-store.addBank = function(uuid, id, pwd, maybeWebsite) {
-    backend.addBank(uuid, id, pwd, maybeWebsite).then(() => {
+store.addBank = function(uuid, id, pwd, maybeCustomFields) {
+    backend.addBank(uuid, id, pwd, maybeCustomFields).then(() => {
         flux.dispatch({
             type: Events.server.saved_bank
         });
@@ -825,7 +825,7 @@ export let Actions = {
         });
     },
 
-    CreateBank(uuid, login, passwd, website) {
+    CreateBank(uuid, login, passwd, customFields) {
         assert(typeof uuid === 'string' && uuid.length, 'uuid must be a non-empty string');
         assert(typeof login === 'string' && login.length, 'login must be a non-empty string');
         assert(typeof passwd === 'string' && passwd.length, 'passwd must be a non-empty string');
@@ -835,8 +835,8 @@ export let Actions = {
             id: login,
             pwd: passwd
         };
-        if (typeof website !== 'undefined')
-            eventObject.website = website;
+        if (typeof customFields !== 'undefined')
+            eventObject.customFields = customFields;
         flux.dispatch(eventObject);
     },
 
@@ -910,7 +910,7 @@ flux.register(function(action) {
         has(action, 'bankUuid');
         has(action, 'id');
         has(action, 'pwd');
-        store.addBank(action.bankUuid, action.id, action.pwd, action.website);
+        store.addBank(action.bankUuid, action.id, action.pwd, action.customFields);
         break;
 
       case Events.user.created_category:

--- a/server/lib/accounts-manager.js
+++ b/server/lib/accounts-manager.js
@@ -122,7 +122,7 @@ export default class AccountManager {
             return;
         }
 
-        let body = await BANK_HANDLERS[access.bank].FetchAccounts(access.bank, access.login, access.password, access.website);
+        let body = await BANK_HANDLERS[access.bank].FetchAccounts(access.bank, access.login, access.password, access.customFields);
         let accountsWeboob = body[`${access.bank}`];
         let accounts = [];
 
@@ -168,7 +168,7 @@ export default class AccountManager {
             return;
         }
 
-        let body = await BANK_HANDLERS[access.bank].FetchOperations(access.bank, access.login, access.password, access.website);
+        let body = await BANK_HANDLERS[access.bank].FetchOperations(access.bank, access.login, access.password, access.customFields);
         let operationsWeboob = body[`${access.bank}`];
         let operations = [];
         let now = moment();

--- a/server/lib/sources/mock.js
+++ b/server/lib/sources/mock.js
@@ -21,7 +21,7 @@ let hashAccount = (uuid) => {
 
 export let SOURCE_NAME = 'mock';
 
-export let FetchAccounts = async (bankuuid, login, password, website) => {
+export let FetchAccounts = async (bankuuid, login, password, customFields) => {
     let output = {};
 
     let obj = hashAccount(bankuuid);
@@ -190,7 +190,7 @@ let generate = (uuid) => {
     return operations;
 }
 
-export let FetchOperations = (bankuuid, login, password, website) => {
+export let FetchOperations = (bankuuid, login, password, customFields) => {
     return new Promise((accept, reject) => {
         setTimeout(() => {
             accept({

--- a/server/lib/sources/weboob.js
+++ b/server/lib/sources/weboob.js
@@ -1,5 +1,5 @@
 // This module retrieves real values from the weboob backend, by using the given
-// bankuuid / login / password (maybe website) combination.
+// bankuuid / login / password (maybe customFields) combination.
 let log = require('printit')({
     prefix: 'sources/weboob',
     date: true
@@ -11,7 +11,7 @@ import {promisify} from '../../helpers';
 
 export let SOURCE_NAME = 'weboob';
 
-let Fetch = (process, bankuuid, login, password, website) => {
+let Fetch = (process, bankuuid, login, password, customFields) => {
 
     return new Promise((accept, reject) => {
 
@@ -22,8 +22,8 @@ let Fetch = (process, bankuuid, login, password, website) => {
         script.stdin.write(login + '\n');
         script.stdin.write(password + '\n');
 
-        if (typeof website !== 'undefined')
-            script.stdin.write(website + '\n');
+        if (typeof customFields !== 'undefined')
+            script.stdin.write(customFields + '\n');
 
         script.stdin.end();
 
@@ -78,12 +78,12 @@ async function TestInstallAndFetch(...args) {
     throw "Weboob doesn't seem to be installed, skipping fetch.";
 }
 
-export function FetchAccounts(bankuuid, login, password, website, callback) {
-    return TestInstallAndFetch('./weboob/scripts/accounts.sh', bankuuid, login, password, website, callback);
+export function FetchAccounts(bankuuid, login, password, customFields, callback) {
+    return TestInstallAndFetch('./weboob/scripts/accounts.sh', bankuuid, login, password, customFields, callback);
 }
 
-export function FetchOperations(bankuuid, login, password, website, callback) {
-    return TestInstallAndFetch('./weboob/scripts/operations.sh', bankuuid, login, password, website, callback);
+export function FetchOperations(bankuuid, login, password, customFields, callback) {
+    return TestInstallAndFetch('./weboob/scripts/operations.sh', bankuuid, login, password, customFields, callback);
 }
 
 

--- a/server/models/access.js
+++ b/server/models/access.js
@@ -10,7 +10,7 @@ let Access = americano.getModel('bankaccess', {
     bank: String,
     login: String,
     password: String,
-    website: String
+    customFields: String
 });
 
 Access = promisifyModel(Access);
@@ -49,4 +49,3 @@ Access.prototype.hasPassword = function() {
 }
 
 export default Access;
-

--- a/server/models/bank.js
+++ b/server/models/bank.js
@@ -9,8 +9,8 @@ import {promisify, promisifyModel} from '../helpers';
 let Bank = americano.getModel('bank', {
     name: String,
     uuid: String,
-    // TODO websites shouldn't be saved in memory
-    websites: function(x) { return x }
+    // TODO customFields shouldn't be saved in memory
+    customFields: function(x) { return x }
 });
 
 Bank = promisifyModel(Bank);

--- a/weboob/banks-all.json
+++ b/weboob/banks-all.json
@@ -46,82 +46,90 @@
         "name": "Banque Populaire",
         "uuid": "banquepopulaire",
         "backend": "weboob",
-        "websites": [
+        "customFields": [
             {
-                "label": "Alpes",
-                "hostname": "www.ibps.alpes.banquepopulaire.fr"
-            },
-            {
-                "label": "Alsace",
-                "hostname": "www.ibps.alsace.banquepopulaire.fr"
-            },
-            {
-                "label": "Aquitaine Centre atlantique",
-                "hostname": "www.ibps.bpaca.banquepopulaire.fr"
-            },
-            {
-                "label": "Atlantique",
-                "hostname": "www.ibps.atlantique.banquepopulaire.fr"
-            },
-            {
-                "label": "Bourgogne-Franche Comté",
-                "hostname": "www.ibps.bpbfc.banquepopulaire.fr"
-            },
-            {
-                "label": "Crédit Maritime Bretagne Normandie",
-                "hostname": "www.ibps.bretagnenormandie.cmm.groupe.banquepopulaire.fr"
-            },
-            {
-                "label": "Crédit Maritime Atlantique",
-                "hostname": "www.ibps.atlantique.creditmaritime.groupe.banquepopulaire.fr"
-            },
-            {
-                "label": "Crédit Maritime du Littoral du Sud-Ouest",
-                "hostname": "www.ibps.sudouest.creditmaritime.groupe.banquepopulaire.fr"
-            },
-            {
-                "label": "Côte d'azur",
-                "hostname": "www.ibps.cotedazur.banquepopulaire.fr"
-            },
-            {
-                "label": "Loire et Lyonnais",
-                "hostname": "www.ibps.loirelyonnais.banquepopulaire.fr"
-            },
-            {
-                "label": "Lorraine Champagne",
-                "hostname": "www.ibps.lorrainechampagne.banquepopulaire.fr"
-            },
-            {
-                "label": "Massif central",
-                "hostname": "www.ibps.massifcentral.banquepopulaire.fr"
-            },
-            {
-                "label": "Nord",
-                "hostname": "www.ibps.nord.banquepopulaire.fr"
-            },
-            {
-                "label": "Occitane",
-                "hostname": "www.ibps.occitane.banquepopulaire.fr"
-            },
-            {
-                "label": "Ouest",
-                "hostname": "www.ibps.ouest.banquepopulaire.fr"
-            },
-            {
-                "label": "Provence et Corse",
-                "hostname": "www.ibps.provencecorse.banquepopulaire.fr"
-            },
-            {
-                "label": "Rives de Paris",
-                "hostname": "www.ibps.rivesparis.banquepopulaire.fr"
-            },
-            {
-                "label": "Sud",
-                "hostname": "www.ibps.sud.banquepopulaire.fr"
-            },
-            {
-                "label": "Val de France",
-                "hostname": "www.ibps.valdefrance.banquepopulaire.fr"
+                "name": "website",
+                "label": "Website",
+                "labelKey": "settings.website",
+                "type": "select",
+                "values": [
+                    {
+                        "label": "Alpes",
+                        "value": "www.ibps.alpes.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Alsace",
+                        "value": "www.ibps.alsace.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Aquitaine Centre atlantique",
+                        "value": "www.ibps.bpaca.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Atlantique",
+                        "value": "www.ibps.atlantique.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Bourgogne-Franche Comté",
+                        "value": "www.ibps.bpbfc.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Crédit Maritime Bretagne Normandie",
+                        "value": "www.ibps.bretagnenormandie.cmm.groupe.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Crédit Maritime Atlantique",
+                        "value": "www.ibps.atlantique.creditmaritime.groupe.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Crédit Maritime du Littoral du Sud-Ouest",
+                        "value": "www.ibps.sudouest.creditmaritime.groupe.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Côte d'azur",
+                        "value": "www.ibps.cotedazur.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Loire et Lyonnais",
+                        "value": "www.ibps.loirelyonnais.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Lorraine Champagne",
+                        "value": "www.ibps.lorrainechampagne.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Massif central",
+                        "value": "www.ibps.massifcentral.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Nord",
+                        "value": "www.ibps.nord.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Occitane",
+                        "value": "www.ibps.occitane.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Ouest",
+                        "value": "www.ibps.ouest.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Provence et Corse",
+                        "value": "www.ibps.provencecorse.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Rives de Paris",
+                        "value": "www.ibps.rivesparis.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Sud",
+                        "value": "www.ibps.sud.banquepopulaire.fr"
+                    },
+                    {
+                        "label": "Val de France",
+                        "value": "www.ibps.valdefrance.banquepopulaire.fr"
+                    }
+                ]
             }
         ]
     },
@@ -178,162 +186,170 @@
         "name": "Crédit Agricole",
         "uuid": "cragr",
         "backend": "weboob",
-        "websites": [
+        "customFields": [
             {
-                "label":"Alpes Provence",
-                "hostname": "m.ca-alpesprovence.fr"
-            },
-            {
-                "label":"Alsace-Vosges",
-                "hostname": "m.ca-alsace-vosges.fr"
-            },
-            {
-                "label":"Anjou Maine",
-                "hostname": "m.ca-anjou-maine.fr"
-            },
-            {
-                "label":"Aquitaine",
-                "hostname": "m.ca-aquitaine.fr"
-            },
-            {
-                "label":"Atlantique Vendée",
-                "hostname": "m.ca-atlantique-vendee.fr"
-            },
-            {
-                "label":"Brie Picardie",
-                "hostname": "m.ca-briepicardie.fr"
-            },
-            {
-                "label":"Champagne Bourgogne",
-                "hostname": "m.ca-cb.fr"
-            },
-            {
-                "label":"Centre France",
-                "hostname": "m.ca-centrefrance.fr"
-            },
-            {
-                "label":"Centre Loire",
-                "hostname": "m.ca-centreloire.fr"
-            },
-            {
-                "label":"Centre Ouest",
-                "hostname": "m.ca-centreouest.fr"
-            },
-            {
-                "label":"Centre Est",
-                "hostname": "m.ca-centrest.fr"
-            },
-            {
-                "label":"Charente Périgord",
-                "hostname": "m.ca-charente-perigord.fr"
-            },
-            {
-                "label":"Charente-Maritime Deux-Sèvres",
-                "hostname": "m.ca-cmds.fr"
-            },
-            {
-                "label":"Corse",
-                "hostname": "m.ca-corse.fr"
-            },
-            {
-                "label":"Côtes d'Armor",
-                "hostname": "m.ca-cotesdarmor.fr"
-            },
-            {
-                "label":"Des Savoie",
-                "hostname": "m.ca-des-savoie.fr"
-            },
-            {
-                "label":"Finistere",
-                "hostname": "m.ca-finistere.fr"
-            },
-            {
-                "label":"Franche-Comté",
-                "hostname": "m.ca-franchecomte.fr"
-            },
-            {
-                "label":"Guadeloupe",
-                "hostname": "m.ca-guadeloupe.fr"
-            },
-            {
-                "label":"Ille-et-Vilaine",
-                "hostname": "m.ca-illeetvilaine.fr"
-            },
-            {
-                "label":"Languedoc",
-                "hostname": "m.ca-languedoc.fr"
-            },
-            {
-                "label":"Loire Haute Loire",
-                "hostname": "m.ca-loirehauteloire.fr"
-            },
-            {
-                "label":"Lorraine",
-                "hostname": "m.ca-lorraine.fr"
-            },
-            {
-                "label":"Martinique Guyane",
-                "hostname": "m.ca-martinique.fr"
-            },
-            {
-                "label":"Morbihan",
-                "hostname": "m.ca-morbihan.fr"
-            },
-            {
-                "label":"Nord Midi-Pyrénées",
-                "hostname": "m.ca-nmp.fr"
-            },
-            {
-                "label":"Nord Est",
-                "hostname": "m.ca-nord-est.fr"
-            },
-            {
-                "label":"Nord de France",
-                "hostname": "m.ca-norddefrance.fr"
-            },
-            {
-                "label":"Normandie Seine",
-                "hostname": "m.ca-normandie-seine.fr"
-            },
-            {
-                "label":"Normandie",
-                "hostname": "m.ca-normandie.fr"
-            },
-            {
-                "label":"Ile-de-France",
-                "hostname": "m.ca-paris.fr"
-            },
-            {
-                "label":"Provence Côte d'Azur",
-                "hostname": "m.ca-pca.fr"
-            },
-            {
-                "label":"Réunion",
-                "hostname": "m.ca-reunion.fr"
-            },
-            {
-                "label":"Sud Méditerranée",
-                "hostname": "m.ca-sudmed.fr"
-            },
-            {
-                "label":"Sud Rhône Alpes",
-                "hostname": "m.ca-sudrhonealpes.fr"
-            },
-            {
-                "label":"Toulouse 31",
-                "hostname": "m.ca-toulouse31.fr"
-            },
-            {
-                "label":"Tourraine Poitou",
-                "hostname": "m.ca-tourainepoitou.fr"
-            },
-            {
-                "label":"Val de France",
-                "hostname": "m.ca-valdefrance.fr"
-            },
-            {
-                "label":"Pyrénées Gascogne",
-                "hostname": "m.lefil.com"
+                "name": "website",
+                "label": "Website",
+                "labelKey": "settings.website",
+                "type": "select",
+                "values": [
+                    {
+                        "label":"Alpes Provence",
+                        "value": "m.ca-alpesprovence.fr"
+                    },
+                    {
+                        "label":"Alsace-Vosges",
+                        "value": "m.ca-alsace-vosges.fr"
+                    },
+                    {
+                        "label":"Anjou Maine",
+                        "value": "m.ca-anjou-maine.fr"
+                    },
+                    {
+                        "label":"Aquitaine",
+                        "value": "m.ca-aquitaine.fr"
+                    },
+                    {
+                        "label":"Atlantique Vendée",
+                        "value": "m.ca-atlantique-vendee.fr"
+                    },
+                    {
+                        "label":"Brie Picardie",
+                        "value": "m.ca-briepicardie.fr"
+                    },
+                    {
+                        "label":"Champagne Bourgogne",
+                        "value": "m.ca-cb.fr"
+                    },
+                    {
+                        "label":"Centre France",
+                        "value": "m.ca-centrefrance.fr"
+                    },
+                    {
+                        "label":"Centre Loire",
+                        "value": "m.ca-centreloire.fr"
+                    },
+                    {
+                        "label":"Centre Ouest",
+                        "value": "m.ca-centreouest.fr"
+                    },
+                    {
+                        "label":"Centre Est",
+                        "value": "m.ca-centrest.fr"
+                    },
+                    {
+                        "label":"Charente Périgord",
+                        "value": "m.ca-charente-perigord.fr"
+                    },
+                    {
+                        "label":"Charente-Maritime Deux-Sèvres",
+                        "value": "m.ca-cmds.fr"
+                    },
+                    {
+                        "label":"Corse",
+                        "value": "m.ca-corse.fr"
+                    },
+                    {
+                        "label":"Côtes d'Armor",
+                        "value": "m.ca-cotesdarmor.fr"
+                    },
+                    {
+                        "label":"Des Savoie",
+                        "value": "m.ca-des-savoie.fr"
+                    },
+                    {
+                        "label":"Finistere",
+                        "value": "m.ca-finistere.fr"
+                    },
+                    {
+                        "label":"Franche-Comté",
+                        "value": "m.ca-franchecomte.fr"
+                    },
+                    {
+                        "label":"Guadeloupe",
+                        "value": "m.ca-guadeloupe.fr"
+                    },
+                    {
+                        "label":"Ille-et-Vilaine",
+                        "value": "m.ca-illeetvilaine.fr"
+                    },
+                    {
+                        "label":"Languedoc",
+                        "value": "m.ca-languedoc.fr"
+                    },
+                    {
+                        "label":"Loire Haute Loire",
+                        "value": "m.ca-loirehauteloire.fr"
+                    },
+                    {
+                        "label":"Lorraine",
+                        "value": "m.ca-lorraine.fr"
+                    },
+                    {
+                        "label":"Martinique Guyane",
+                        "value": "m.ca-martinique.fr"
+                    },
+                    {
+                        "label":"Morbihan",
+                        "value": "m.ca-morbihan.fr"
+                    },
+                    {
+                        "label":"Nord Midi-Pyrénées",
+                        "value": "m.ca-nmp.fr"
+                    },
+                    {
+                        "label":"Nord Est",
+                        "value": "m.ca-nord-est.fr"
+                    },
+                    {
+                        "label":"Nord de France",
+                        "value": "m.ca-norddefrance.fr"
+                    },
+                    {
+                        "label":"Normandie Seine",
+                        "value": "m.ca-normandie-seine.fr"
+                    },
+                    {
+                        "label":"Normandie",
+                        "value": "m.ca-normandie.fr"
+                    },
+                    {
+                        "label":"Ile-de-France",
+                        "value": "m.ca-paris.fr"
+                    },
+                    {
+                        "label":"Provence Côte d'Azur",
+                        "value": "m.ca-pca.fr"
+                    },
+                    {
+                        "label":"Réunion",
+                        "value": "m.ca-reunion.fr"
+                    },
+                    {
+                        "label":"Sud Méditerranée",
+                        "value": "m.ca-sudmed.fr"
+                    },
+                    {
+                        "label":"Sud Rhône Alpes",
+                        "value": "m.ca-sudrhonealpes.fr"
+                    },
+                    {
+                        "label":"Toulouse 31",
+                        "value": "m.ca-toulouse31.fr"
+                    },
+                    {
+                        "label":"Tourraine Poitou",
+                        "value": "m.ca-tourainepoitou.fr"
+                    },
+                    {
+                        "label":"Val de France",
+                        "value": "m.ca-valdefrance.fr"
+                    },
+                    {
+                        "label":"Pyrénées Gascogne",
+                        "value": "m.lefil.com"
+                    }
+                ]
             }
         ]
     },
@@ -365,13 +381,33 @@
         "docType": "Bank",
         "name": "HSBC",
         "uuid": "hsbc",
-        "backend": "weboob"
+        "backend": "weboob",
+        "customFields": [
+            {
+                "name": "secret",
+                "type": "password",
+                "label": "Secret",
+                "labelKey": "settings.secret",
+                "placeholder": "Enter here your secret phrase",
+                "placeholderKey": "settings.secretPlaceholder"
+            }
+        ]
     },
     {
         "docType": "Bank",
         "name": "ING Direct",
         "uuid": "ing",
-        "backend": "weboob"
+        "backend": "weboob",
+        "customFields": [
+            {
+                "name": "birthday",
+                "type": "number",
+                "label": "Birthday",
+                "labelKey": "settings.birthday",
+                "placeholder": "DDMMYYYY",
+                "placeholderKey": "settings.birthdayPlaceholder"
+            }
+        ]
     },
     {
         "docType": "Bank",

--- a/weboob/py/endpoint.py
+++ b/weboob/py/endpoint.py
@@ -20,10 +20,13 @@ class BaseBankHandler(object):
     Base class to handle utility methods.
     '''
 
-    def __init__(self, login, password, website = None):
+    def __init__(self, login, password, customFields = None):
         self.login = login
         self.password = password
-        self.website = website
+        self.customFields = customFields
+
+        if  self.customFields is not None:
+            self.customFields = json.loads(self.customFields)
 
     def load_from_connector(self, name):
         '''
@@ -34,15 +37,16 @@ class BaseBankHandler(object):
 
         * login
         * password
-        * website (optional)
+        * customFields (optional)
         '''
         params_connector = {
             'login': self.login,
             'password': self.password,
         }
 
-        if self.website is not None:
-            params_connector['website'] = self.website
+        if self.customFields is not None:
+            for f in self.customFields:
+                params_connector[f["name"]] = f["value"]
 
         results = {}
         try:
@@ -100,7 +104,7 @@ class BankHistoryHandler(BaseBankHandler):
         """
         return self.load_from_connector(name)
 
-# Arguments format: {'account' | 'history'} bankuuid login password maybe_website
+# Arguments format: {'account' | 'history'} bankuuid login password maybeCustomFields
 
 args = []
 requested_content = None
@@ -117,15 +121,15 @@ if len(args) < 3:
 bankuuid = args[0]
 id = args[1]
 password = args[2]
-website = None
+customFields = None
 if len(args) == 4:
-    website = args[3]
+    customFields = args[3]
 
 content = None
 if requested_content == 'account':
-    content = BankHandler(id, password, website).post(bankuuid)
+    content = BankHandler(id, password, customFields).post(bankuuid)
 elif requested_content == 'history':
-    content = BankHistoryHandler(id, password, website).post(bankuuid)
+    content = BankHistoryHandler(id, password, customFields).post(bankuuid)
 
 assert(content is not None)
 print json.dumps(content, ensure_ascii=False).encode('utf-8')


### PR DESCRIPTION
Added the ability to define custom fields for the bank accounts that will be used for the connection to the website.

Ex: the birthday date for *ING Direct* or the secret phrase for *HSBC*.
The former "website" fields (*Crédit Agricole* and *Banque Populaire*) are now custom fields too.

Tested with *ING Direct* and *Crédit Agricole*.