### PR TITLE
Added check for virtualenv's name

### DIFF
--- a/weboob/scripts/install.sh
+++ b/weboob/scripts/install.sh
@@ -2,4 +2,14 @@
 
 cd weboob
 rm -rf env
-mkdir -p ./env && virtualenv ./env && source ./env/bin/activate && pip install -r requirements.txt && cd .. && ./weboob/scripts/test.sh
+
+# Let's find out if Python's virtualenv is installed and, if so, what name its binary has
+pyvenv=$(which virtualenv || which virtualenv2 || echo "")
+if [[ -z $pyvenv ]]
+then
+    # Virtualenv isn't installed, we abort the installation
+    echo "Virtualenv is not installed"
+    exit 1
+fi
+
+mkdir -p ./env && $pyvenv ./env && source ./env/bin/activate && pip install -r requirements.txt && cd .. && ./weboob/scripts/test.sh


### PR DESCRIPTION
Added a bash condition which will check if virtualenv is installed by checking both `virtualenv` and `virtualenv2` (for distros supporting Python 3 which had to rename Python 2 binaries), and stops the installation if not installed.

Fixes #252.