### PR TITLE
Truncate operations labels in Chrome

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -369,6 +369,28 @@ ul {
     padding-left: 12px;
 }
 
+/*
+* WebKit hack: by setting a relative position to the cell, its width will not be
+* calculated according to its content, which is wrong if the content is too wide
+*/
+.operation-panel .table td:nth-child(4)
+{
+    position: relative;
+}
+
+.operation-panel .table td:nth-child(4) button
+{
+    position: absolute;
+    max-width: calc(100% - 16px);
+    max-width: -webkit-fill-available;
+}
+
+.operation-panel .table td:nth-child(4) .input-group-addon + button
+{
+    /* 52px = .input-group paddings (12+12) + 2 icons max (28px) */
+    max-width: calc(100% - 52px);
+}
+
 .clickable {
     cursor: pointer;
 }


### PR DESCRIPTION
CSS Hack to truncate operations labels in Chrome/Safari
Fix #278

Worst case scenario : there are icons displayed on the left of the label and we can't detect which space remains. In this case, we take all the space minus the width of 2 icons (file and future), see below: the first label is shorter than the others.

![kresus-capture-labels](https://cloud.githubusercontent.com/assets/3419050/12063477/8ad4848a-afaf-11e5-9485-8a4fb74b4a48.png)


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bnjbvr/kresus/309)
<!-- Reviewable:end -->
