### PR TITLE
Dont push files to server if JSON.parse failed when importing instance

### DIFF
--- a/client/components/ImportModule.js
+++ b/client/components/ImportModule.js
@@ -19,12 +19,17 @@ export default class ImportModule extends React.Component {
             let asJSON;
             try {
                 asJSON = JSON.parse(asText);
+
+                Actions.ImportInstance({
+                    content: asJSON
+                });
             } catch(e) {
-                alert('JSON file to import isnt valid!');
+                if (e instanceof SyntaxError) {
+                    alert('JSON file to import isnt valid!');
+                } else {
+                    alert(`Unexpected error: ${ex.message}`);
+                }
             }
-            Actions.ImportInstance({
-                content: asJSON
-            });
         }
         fileReader.readAsText($importFile.files[0]);
 


### PR DESCRIPTION
Hey !

I figured out when you try to import you previous Kresus instance, the code checks whether this is a valid json file and if not, an alert is shown. Though an empty request is still sent to the backend which fails and display another alert.

This little fix just avoids calling backend if `JSON.parse` fails.