### PR TITLE
Stop redender components on changing of view.

### DIFF
--- a/client/components/categories/index.js
+++ b/client/components/categories/index.js
@@ -10,7 +10,7 @@ export default class CategoryList extends React.Component {
         super(props);
         this.state = {
             showForm: false,
-            categories: []
+            categories: store.getCategories()
         };
 
         this.listener = this.listener.bind(this);
@@ -25,7 +25,7 @@ export default class CategoryList extends React.Component {
     }
 
     componentDidMount() {
-        store.subscribeMaybeGet(State.categories, this.listener);
+        store.on(State.categories, this.listener);
     }
 
     componentWillUnmount() {

--- a/client/components/charts/Charts.js
+++ b/client/components/charts/Charts.js
@@ -42,9 +42,9 @@ export default class ChartsComponent extends React.Component {
         super(props);
 
         this.state = {
-            account: null,
-            operations: [],
-            categories: [],
+            account: store.getCurrentAccount(),
+            operations: store.getCurrentOperations(),
+            categories: store.getCategories(),
             kind: 'all'         // which chart are we showing?
         }
 
@@ -71,7 +71,7 @@ export default class ChartsComponent extends React.Component {
         // Obviously new categories means new graphs.
         store.on(State.categories, this.reload);
 
-        store.subscribeMaybeGet(State.operations, this.reload);
+        store.on(State.operations, this.reload);
     }
 
     componentWillUnmount() {

--- a/client/components/duplicates/index.js
+++ b/client/components/duplicates/index.js
@@ -50,7 +50,8 @@ export default class Similarity extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            pairs: []
+            pairs: findRedundantPairs(store.getCurrentOperations(),
+                                      store.getSetting('duplicateThreshold'))
         };
         this.listener = this.listener.bind(this);
     }
@@ -65,7 +66,7 @@ export default class Similarity extends React.Component {
     componentDidMount() {
         store.on(State.banks, this.listener);
         store.on(State.accounts, this.listener);
-        store.subscribeMaybeGet(State.operations, this.listener);
+        store.on(State.operations, this.listener);
     }
 
     componentWillUnmount() {

--- a/client/components/menu/accounts.js
+++ b/client/components/menu/accounts.js
@@ -65,8 +65,8 @@ export default class AccountListComponent extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            accounts: [],
-            active: null,
+            accounts: store.getCurrentBankAccounts(),
+            active: store.getCurrentAccountId(),
             showDropdown: false
         };
         this.listener = this.listener.bind(this);
@@ -88,7 +88,7 @@ export default class AccountListComponent extends React.Component {
     componentDidMount() {
         store.on(State.banks, this.listener);
         store.on(State.operations, this.listener);
-        store.subscribeMaybeGet(State.accounts, this.listener);
+        store.on(State.accounts, this.listener);
     }
 
     componentWillUnmount() {

--- a/client/components/menu/banks.js
+++ b/client/components/menu/banks.js
@@ -59,7 +59,8 @@ export default class BankListComponent extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            banks: [],
+            banks: store.getBanks(),
+            active: store.getCurrentBankId(),
             showDropdown: false
         };
         this.listener = this.listener.bind(this);
@@ -79,7 +80,7 @@ export default class BankListComponent extends React.Component {
     }
 
     componentDidMount() {
-        store.subscribeMaybeGet(State.banks, this.listener);
+        store.on(State.banks, this.listener);
     }
 
     componentWillUnmount() {

--- a/client/components/operations/OperationList.js
+++ b/client/components/operations/OperationList.js
@@ -18,8 +18,8 @@ export default class OperationsComponent extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            account: null,
-            operations: [],
+            account: store.getCurrentAccount(),
+            operations: store.getCurrentOperations(),
             filteredOperations: [],
             lastItemShown: SHOW_ITEMS_INITIAL,
             hasFilteredOperations: false
@@ -39,7 +39,7 @@ export default class OperationsComponent extends React.Component {
     componentDidMount() {
         store.on(State.banks, this.listener);
         store.on(State.accounts, this.listener);
-        store.subscribeMaybeGet(State.operations, this.listener);
+        store.on(State.operations, this.listener);
     }
 
     componentWillUnmount() {

--- a/client/components/settings/BankAccounts.js
+++ b/client/components/settings/BankAccounts.js
@@ -11,7 +11,7 @@ export default class BankAccounts extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            accounts: []
+            accounts: store.getBankAccounts(this.props.bank.id)
         };
         this.listener = this._listener.bind(this);
         this.handleChangeAccess = this.handleChangeAccess.bind(this);
@@ -24,7 +24,7 @@ export default class BankAccounts extends React.Component {
     }
 
     componentDidMount() {
-        store.subscribeMaybeGet(State.accounts, this.listener);
+        store.on(State.accounts, this.listener);
     }
 
     componentWillUnmount() {

--- a/client/components/settings/BankAccountsList.js
+++ b/client/components/settings/BankAccountsList.js
@@ -8,7 +8,7 @@ export default class BankAccountsList extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            banks: []
+            banks: store.getBanks()
         };
         this.listener = this._listener.bind(this);
     }
@@ -20,7 +20,7 @@ export default class BankAccountsList extends React.Component {
     }
 
     componentDidMount() {
-        store.subscribeMaybeGet(State.banks, this.listener);
+        store.on(State.banks, this.listener);
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
Removed all the subscribeMaybeGet calls (simple suscribe to the event State.*), as
all the information are now loaded before mounting and rendering the component.