### PR TITLE
Allow users to encrypt their backup

### DIFF
--- a/server/controllers/routes.js
+++ b/server/controllers/routes.js
@@ -15,7 +15,9 @@ module.exports = {
         post: all.import
     },
     'all/export': {
-        get: all.export
+        // FIXME: deprecated
+        get: all.oldExport,
+        post: all.export
     },
 
     // Accesses


### PR DESCRIPTION
I figured out backups were a plain json file. IMO it should be better to leave the user encrypting the file before exporting it.

I added 2 routes offering an encryption method:
- `POST /all/export/encrypted` expects a JSON body with a `passphrase` key.
- `POST /all/import/encrypted` expects a JSON body with `all` and `passphrase` keys.

If you wonder why I use `POST`, it's only to avoid to log the passphrase (it's still a bit confusing).

I'm so sorry but I can't deal with React. And even if I tried, I think you'll do better than me!

Cheers