### PR TITLE
Send email when no password is set + extends no_password error to the…

### DIFF
--- a/server/controllers/accesses.js
+++ b/server/controllers/accesses.js
@@ -92,7 +92,7 @@ export async function fetchAccounts(req, res) {
     try {
         let access = req.preloaded.access;
         await commonAccountManager.retrieveAndAddAccountsByAccess(access);
-        fetchOperations(req, res);
+        await fetchOperations(req, res);
     } catch (err) {
         return asyncErr(res, err, 'when fetching accounts');
     }
@@ -118,7 +118,7 @@ export async function update(req, res) {
             throw new KError('missing password', 400);
 
         await req.preloaded.access.updateAttributes(access);
-        res.sendStatus(200);
+        await fetchAccounts(req, res);
     } catch (err) {
         return asyncErr(res, err, 'when updating bank access');
     }

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -116,5 +116,6 @@ export function promisifyModel(model) {
 export function isCredentialError(err) {
     return err.errCode === getErrorCode('INVALID_PASSWORD') ||
            err.errCode === getErrorCode('EXPIRED_PASSWORD') ||
-           err.errCode === getErrorCode('INVALID_PARAMETERS');
+           err.errCode === getErrorCode('INVALID_PARAMETERS') ||
+           err.errCode === getErrorCode('NO_PASSWORD');
 }

--- a/server/lib/poller.js
+++ b/server/lib/poller.js
@@ -39,8 +39,6 @@ class Poller
         }
 
         this.timeout = setTimeout(this.run, nextUpdate.diff(now));
-
-        this.sentNoPasswordNotification = false;
     }
 
     async run(cb) {
@@ -117,7 +115,6 @@ class Poller
 
             // Done!
             log.info('All accounts have been polled.');
-            this.sentNoPasswordNotification = false;
 
         } catch (err) {
             log.error(`Error when polling accounts: ${err.message}`);

--- a/server/models/access.js
+++ b/server/models/access.js
@@ -49,15 +49,18 @@ Access.allLike = async function allLike(access) {
 
 // Sync function
 Access.prototype.hasPassword = function() {
-    return typeof this._passwordStillEncrypted === 'undefined' ||
-           !this._passwordStillEncrypted;
+    return (typeof this._passwordStillEncrypted === 'undefined' ||
+           !this._passwordStillEncrypted) &&
+           // Can happen after import of kresus data
+           typeof this.password !== 'undefined';
 };
 
 // Can the access be polled
 Access.prototype.canAccessBePolled = function() {
     return this.fetchStatus !== 'INVALID_PASSWORD' &&
             this.fetchStatus !== 'EXPIRED_PASSWORD' &&
-            this.fetchStatus !== 'INVALID_PARAMETERS';
+            this.fetchStatus !== 'INVALID_PARAMETERS' &&
+            this.fetchStatus !== 'NO_PASSWORD';
 };
 
 module.exports = Access;

--- a/shared/locales/en.js
+++ b/shared/locales/en.js
@@ -401,11 +401,11 @@ Your accounts' balances:`,
                 INVALID_PARAMETERS: 'The credentials are invalid',
                 GENERIC_EXCEPTION: 'Unknown error',
                 text: `Kresus detected the following error when fetching operations from the bank %{bank}: \n%{error} (%{message}).\n`,
-                pause_poll:'Please note no automatic polling will be retried until you fix the problem AND manually refetch operations for this account'
+                pause_poll:'Please note no automatic polling will be retried until you fix the problem'
             }
         },
         notification: {
-            new_operation: `Kresus: %{smart_count} new transaction imported |||| %{smart_count} new transactions imported`
+            new_operation: `Kresus: %{smart_count} new transaction imported |||| Kresus: %{smart_count} new transactions imported`
         }
     }
 };

--- a/shared/locales/fr.js
+++ b/shared/locales/fr.js
@@ -401,11 +401,11 @@ Solde de vos comptes :`,
                 INVALID_PARAMETERS: 'Les paramètres de connexion sont invalides',
                 GENERIC_EXCEPTION: 'Erreur inconnue',
                 text: `Kresus a détecté les erreurs suivantes lors de la récuperation des operations des comptes attachés à la banque %{bank}: \n%{error} (%{message}).\n`,
-                pause_poll: "Veuillez noter qu'aucun import d'opération automatique ne sera tenté tant que vous n'avez pas corrigé les problèmes de connexion, ET effectué un import manuel des operations pour ce compte."
+                pause_poll: "Veuillez noter qu'aucun import d'opération automatique ne sera tenté tant que vous n'avez pas corrigé les problèmes de connexion."
             }
         },
         notification: {
-            new_operation: `Kresus: %{smart_count} nouvelle operation importée ||||  %{smart_count} nouvelles operations importées`
+            new_operation: `Kresus: %{smart_count} nouvelle operation importée |||| Kresus: %{smart_count} nouvelles operations importées`
         }
     }
 };


### PR DESCRIPTION
… case when the password of an access is undefined (can happen after the import of an instance) + Fetch account and operations on password update (client counterpart still needs to be implemetented: retrieve accounts and operations) + Minor fixes for notifications