### PR TITLE
Use /kresus/app/ as Cloud9 workspace by default

### DIFF
--- a/docker/Dockerfile-janitor
+++ b/docker/Dockerfile-janitor
@@ -39,7 +39,7 @@ RUN echo "\n# Kresus configuration." >> /home/user/.bashrc \
  && echo "export PORT=\"9876\"" >> /home/user/.bashrc
 
 # Configure Cloud9 to use Kresus's source directory as workspace (-w).
-RUN sudo sed -i "s/-w \/home\/user/-w \/home\/user\/kresus/" /etc/supervisord.conf
+RUN sudo sed -i "s/-w \/home\/user/-w \/home\/user\/kresus\/app/" /etc/supervisord.conf
 
 # Expose the port on which Kresus will be running.
 EXPOSE 9876


### PR DESCRIPTION
It was previously hard-coded to /home/user/kresus/app/ on janitor.technology, but this was lost when switching to Cloud9 SDK.